### PR TITLE
Add an arbitary-sized nat serializer

### DIFF
--- a/lib/Binary.v
+++ b/lib/Binary.v
@@ -3,6 +3,8 @@ Import ListNotations.
 Require Import Arith.
 Require Import Nat.
 Require Import Ascii.
+Require Import Omega.
+Require Import StructTactics.
 
 Fixpoint take_rec (acc: list bool) c xs :=
   match c with
@@ -77,6 +79,31 @@ Fixpoint binary_to_nat_rec bin :=
 
 Definition binary_to_nat bin :=
   binary_to_nat_rec (List.rev bin).
+
+Lemma binary_to_nat_to_binary_rec :
+  forall fuel n,
+    n <= fuel ->
+    binary_to_nat_rec (nat_to_binary_rec fuel n) = n.
+Proof.
+  induction fuel; intros n Hfuel.
+  - simpl. omega.
+  - cbn [nat_to_binary_rec].
+    destruct n; auto.
+    cbn [binary_to_nat_rec].
+    rewrite IHfuel by eauto using le_trans, Nat.le_div2 with *.
+    now rewrite plus_comm, <- Nat.div2_odd.
+Qed.
+
+Lemma binary_to_nat_to_binary :
+  forall n,
+    binary_to_nat (nat_to_binary n) = n.
+Proof.
+  intros n.
+  unfold binary_to_nat, nat_to_binary.
+  rewrite rev_involutive.
+  apply binary_to_nat_to_binary_rec.
+  apply le_refl.
+Qed.
 
 Definition int_to_binary i :=
   add_zeroes (nat_to_binary i) 31.

--- a/lib/Binary.v
+++ b/lib/Binary.v
@@ -61,7 +61,7 @@ Fixpoint nat_to_binary_rec fuel n :=
     | S fuel =>
   match n with
     | O => nil
-    | _ => (eqb (modulo n 2) 1) :: nat_to_binary_rec fuel (div2 n)
+    | _ => (Nat.odd n) :: nat_to_binary_rec fuel (div2 n)
   end
   end.
 
@@ -72,10 +72,7 @@ Fixpoint binary_to_nat_rec bin :=
   match bin with
     | nil => 0
     | hd::bin =>
-      (match hd with
-         | true => 1
-         | false => 0
-       end) + 2 * (binary_to_nat_rec bin)
+      Nat.b2n hd + 2 * (binary_to_nat_rec bin)
   end.
 
 Definition binary_to_nat bin :=

--- a/lib/Binary.v
+++ b/lib/Binary.v
@@ -1,4 +1,5 @@
 Require Import List.
+Import ListNotations.
 Require Import Arith.
 Require Import Nat.
 Require Import Ascii.
@@ -27,6 +28,32 @@ Definition add_zeroes bin len :=
     bin
   else
     add_zeroes_rec bin (len - (length bin)).
+
+Fixpoint nat_to_unary n : list bool :=
+  match n with
+  | 0 => [false]
+  | S n' => true :: nat_to_unary n'
+  end.
+
+Fixpoint unary_to_nat (bin : list bool) : option (nat * list bool) :=
+  match bin with
+  | [] => None
+  | b :: bin' => if b
+                then match unary_to_nat bin' with
+                     | None => None
+                     | Some (n, rest) => Some (S n, rest)
+                     end
+                else Some (0, bin')
+  end.
+
+Lemma nat_to_unary_to_nat :
+  forall n bin,
+    unary_to_nat (nat_to_unary n ++ bin) = Some (n, bin).
+Proof.
+  induction n as [|n' IHn']; intros bin.
+  - reflexivity.
+  - simpl. now rewrite IHn'.
+Qed.
 
 Fixpoint nat_to_binary_rec fuel n :=
   match fuel with

--- a/lib/Binary.v
+++ b/lib/Binary.v
@@ -19,6 +19,26 @@ Fixpoint take_rec (acc: list bool) c xs :=
 Definition take c xs :=
   take_rec nil c xs.
 
+Lemma take_rec_app :
+  forall xs ys acc,
+    take_rec acc (length xs) (xs ++ ys) = Some (rev acc ++ xs, ys).
+Proof.
+  induction xs; simpl; intros ys acc.
+  - now rewrite app_nil_r.
+  - rewrite IHxs.
+    simpl.
+    now rewrite app_assoc_reverse.
+Qed.
+
+Lemma take_app :
+  forall xs ys,
+    take (length xs) (xs ++ ys) = Some (xs, ys).
+Proof.
+  unfold take.
+  intros xs ys.
+  now rewrite take_rec_app.
+Qed.
+
 Fixpoint add_zeroes_rec (bin: list bool) length_left :=
   match length_left with
     | O => bin

--- a/lib/Types.v
+++ b/lib/Types.v
@@ -1,4 +1,5 @@
 Require Import List.
+Require Import Binary.
 
 Class Serializer A :=
   {
@@ -31,3 +32,31 @@ Instance Bool_Serializer: Serializer bool :=
 intros; simpl.
 reflexivity.
 Qed.
+
+Definition nat_serialize (n : nat) : list bool :=
+  let bin := nat_to_binary n
+  in nat_to_unary (length bin) ++ bin.
+
+Definition nat_deserialize (bin : list bool) : option (nat * list bool) :=
+  match unary_to_nat bin with None => None
+  | Some (n, bin) =>
+  match take n bin with None => None
+  | Some (bin_n, bin) =>
+    Some (binary_to_nat bin_n, bin)
+  end
+  end.
+
+Lemma nat_serialize_reversible : forall n bin,
+    nat_deserialize (nat_serialize n ++ bin) = Some (n, bin).
+Proof.
+  unfold nat_deserialize, nat_serialize.
+  intros n bin.
+  now rewrite app_assoc_reverse, nat_to_unary_to_nat, take_app, binary_to_nat_to_binary.
+Qed.
+
+Instance Nat_Serializer : Serializer nat :=
+  {
+    serialize := nat_serialize;
+    deserialize := nat_deserialize;
+    Serialize_reversible := nat_serialize_reversible
+  }.


### PR DESCRIPTION
This PR implements a serializer for arbitrarily large nats. This is a little difficult because the deserializer needs to be able to detect the end of the number, so a simple binary encoding will not work. 

Instead, we use the fact that it is easy to (inefficiently) serialize nats in unary notation by emitting a stream of `n` 1-bits followed by a 0-bit. The 0-bit marks the end and is easy to detect in the deserializer. We then use the unary serializer to bootstrap the binary serializer by writing out the length of the binary encoding in unary, followed by the binary encoding itself. The deserializer first reads the length in unary, and then `take`s that many bits and passes them to the binary deserializer.

The result is an encoding that is twice as bloated as a binary encoding would be, but it is relatively straightforward to prove correct.
