### PR TITLE
Add conversion-based serializers and a serializer for Z

### DIFF
--- a/lib/Binary.v
+++ b/lib/Binary.v
@@ -113,3 +113,139 @@ Proof.
   apply binary_to_nat_to_binary_rec.
   apply le_refl.
 Qed.
+
+Fixpoint bits_of (n_bits : nat) (x : nat) : (list bool * nat) :=
+  match n_bits with
+  | 0 => ([], x)
+  | S n_bits' => let (l,x') := bits_of n_bits' (Nat.div2 x)
+                in (Nat.odd x :: l, x')
+  end.
+
+Lemma length_bits_of :
+  forall n x l x', bits_of n x = (l, x') ->
+              length l = n.
+Proof.
+  induction n; simpl; intros x l x' H.
+  - find_inversion. auto.
+  - break_let. apply IHn in Heqp.
+    find_inversion. auto.
+Qed.
+
+Fixpoint uleb128_encode' fuel n : list bool :=
+  let (byte, n') := bits_of 7 n
+  in match n' with
+     | 0 => false :: byte
+     | S _ => true :: byte ++
+             match fuel with
+             | 0 => []
+             | S fuel' => uleb128_encode' fuel' n'
+             end
+     end.
+Definition uleb128_encode n := uleb128_encode' n n.
+
+Fixpoint uleb128_decode (bin : list bool) : option (nat * list bool) :=
+  match bin with
+  | b_cont::b0::b1::b2::b3::b4::b5::b6::bin' =>
+    let n := binary_to_nat_rec [b0;b1;b2;b3;b4;b5;b6]
+    in if b_cont
+       then match uleb128_decode bin' with None => None
+            | Some (ans, bin'') => Some (n + 128 * ans, bin'')
+            end
+       else Some (n, bin')
+  | _ => None
+  end.
+
+Lemma shiftr_div2_comm :
+  forall b a,
+    Nat.shiftr (Nat.div2 a) b = Nat.div2 (Nat.shiftr a b).
+Proof.
+  induction b; simpl; intros a; auto using f_equal.
+Qed.
+
+Lemma bits_of_x' :
+  forall n x l x',
+    bits_of n x = (l, x') ->
+    x' = Nat.shiftr x n.
+Proof.
+  induction n; simpl; intros x l x' H.
+  - now find_inversion.
+  - break_let. apply IHn in Heqp. find_inversion. apply shiftr_div2_comm.
+Qed.
+
+Lemma mod2n_succ:
+  forall n x : nat, Nat.b2n (Nat.odd x) + 2 * (Nat.div2 x mod 2 ^ n) = x mod 2 ^ S n.
+Proof.
+  intros n x.
+  apply Nat.bits_inj.
+  intro i.
+  repeat rewrite <- Nat.land_ones.
+  repeat rewrite Nat.land_spec.
+  rewrite plus_comm.
+  destruct i.
+  + now rewrite Nat.testbit_0_r, Nat.ones_spec_low, Nat.bit0_odd, Bool.andb_true_r by omega.
+  + rewrite Nat.testbit_succ_r, Nat.land_spec, Nat.div2_spec, Nat.shiftr_specif, plus_comm.
+    f_equal.
+    destruct (lt_dec i n).
+    * now rewrite !Nat.ones_spec_low by omega.
+    * now rewrite !Nat.ones_spec_high by omega.
+Qed.
+
+Lemma bits_of_l :
+  forall n x l x',
+    bits_of n x = (l, x') ->
+    binary_to_nat_rec l = x mod (2 ^ n).
+Proof.
+  induction n; intros x l x' H.
+  - simpl in *. now find_inversion.
+  - cbn [bits_of] in *.
+    break_let. apply IHn in Heqp.
+    find_inversion.
+    cbn [binary_to_nat_rec].
+    rewrite Heqp.
+    apply mod2n_succ.
+Qed.
+
+Lemma bits_of_reconstruct :
+  forall n x l x',
+    bits_of n x = (l, x') ->
+    x = binary_to_nat_rec l + 2 ^ n * x'.
+Proof.
+  intros.
+  find_copy_apply_lem_hyp bits_of_l.
+  find_apply_lem_hyp bits_of_x'.
+  subst.
+  now rewrite Nat.shiftr_div_pow2, H0, plus_comm, <- Nat.div_mod
+    by (apply Nat.pow_nonzero; congruence).
+Qed.
+
+Lemma uleb128_decode_encode' :
+  forall fuel n bin,
+    n <= fuel ->
+    uleb128_decode (uleb128_encode' fuel n ++ bin) = Some (n, bin).
+Proof.
+  induction fuel as [|fuel' IHfuel']; intros n bin Hle.
+  - destruct n.
+    + reflexivity.
+    + omega.
+  - cbn [uleb128_encode'].
+    break_let.
+    find_copy_apply_lem_hyp length_bits_of.
+    do 8 (destruct l; simpl in H; try omega).
+    find_apply_lem_hyp bits_of_reconstruct.
+    subst n.
+    break_match; cbn [app uleb128_decode].
+    + f_equal. f_equal. omega.
+    + rewrite IHfuel'; auto.
+      replace (2 ^ 7) with 128 in * by auto.
+      omega.
+Qed.
+
+Lemma uleb128_decode_encode :
+  forall n bin,
+    uleb128_decode (uleb128_encode n ++ bin) = Some (n, bin).
+Proof.
+  unfold uleb128_encode.
+  intros.
+  apply uleb128_decode_encode'.
+  auto.
+Qed.

--- a/lib/Combinators.v
+++ b/lib/Combinators.v
@@ -168,7 +168,7 @@ Definition list_serialize
            {T: Type}
            {tSerializer: Serializer T}
            (ts: list T) :=
-  nat_serialize (length ts) ++ (list_serialize_rec ts).
+  serialize (length ts) ++ (list_serialize_rec ts).
 
 Fixpoint list_deserialize_rec
          {T: Type}
@@ -191,7 +191,7 @@ Definition list_deserialize
            {T: Type}
            {tSerializer: Serializer T}
            (bin: list bool) : option (list T * list bool) :=
-  match nat_deserialize bin with
+  match deserialize bin with
     | None => None
     | Some (count, rest) =>
       list_deserialize_rec count rest
@@ -206,7 +206,7 @@ Proof.
   unfold list_deserialize, list_serialize.
   intros T tSerializer ts bin.
   rewrite app_assoc_reverse.
-  rewrite nat_serialize_reversible.
+  rewrite Serialize_reversible.
   induction ts; auto.
   simpl.
   rewrite app_assoc_reverse.

--- a/lib/Combinators.v
+++ b/lib/Combinators.v
@@ -176,4 +176,32 @@ Section combinators.
       deserialize := list_deserialize;
       Serialize_reversible := list_serialize_reversible
     }.
+
+  Variable to : B -> A.
+  Variable from : A -> B.
+  Hypothesis to_from_inverse : forall b, from (to b) = b.
+
+  Definition to_from_serialize (b : B) : list bool := serialize (to b).
+
+  Definition to_from_deserialize bin : option (B * list bool) :=
+    match deserialize(A:=A) bin with None => None
+    | Some (a, bin) => Some (from a, bin)
+    end.
+
+  Lemma to_from_serialize_reversible : forall b bin,
+      to_from_deserialize (to_from_serialize b ++ bin) = Some (b, bin).
+  Proof.
+    unfold to_from_serialize, to_from_deserialize.
+    intros b bin.
+    now rewrite Serialize_reversible, to_from_inverse.
+  Qed.
+
+  Global Instance To_From_Serializer : Serializer B :=
+    {
+      serialize := to_from_serialize;
+      deserialize := to_from_deserialize;
+      Serialize_reversible := to_from_serialize_reversible
+    }.
 End combinators.
+Implicit Arguments To_From_Serializer.
+

--- a/lib/Combinators.v
+++ b/lib/Combinators.v
@@ -2,224 +2,178 @@ Require Import StructTactics.
 Require Import List.
 Require Import Types.
 
-Definition option_serialize
-           {T: Type}
-           {tSerializer: Serializer T}
-           (o: option T) :=
-  match o with
+Section combinators.
+  Variable A : Type.
+  Variable sA : Serializer A.
+
+  Definition option_serialize (o: option A) :=
+    match o with
     | None => serialize false
     | Some t => serialize true ++ serialize t
-  end.
+    end.
 
-Definition option_deserialize
-           {T: Type}
-           {tSerializer: Serializer T}
-           (bin: list bool) : option (option T * list bool) :=
-  match deserialize bin with
-  | None => None
-  | Some (b, rest) =>
-  match b with
-  | false => Some (None, rest)
-  | true =>
-  match deserialize rest with
-  | None => None
-  | Some (t, rest) =>
-    Some (Some t, rest)
-  end
-  end
-  end.
-
-Lemma option_serialize_reversible :
-  forall {T: Type}
-    {tSerializer: Serializer T}
-    (o: option T) (bin: list bool),
-    option_deserialize (option_serialize o ++ bin) = Some (o, bin).
-Proof.
-  unfold option_deserialize, option_serialize.
-  intros T tSerializer o bin.
-  destruct o; simpl; auto.
-  now rewrite Serialize_reversible.
-Qed.
-
-Instance Option_Serializer :
-  forall (T: Type)
-    {tSerializer: Serializer T}, Serializer (option T) :=
-  {
-    serialize := option_serialize;
-    deserialize := option_deserialize;
-    Serialize_reversible := option_serialize_reversible
-  }.
-
-Definition pair_serialize
-           {A B: Type}
-           {aSerializer: Serializer A}
-           {bSerializer: Serializer B}
-           (p: A*B) :=
-  let (a, b) := p in
-  (serialize a) ++ (serialize b).
-
-Definition pair_deserialize
-           {A B: Type}
-           {aSerializer: Serializer A}
-           {bSerializer: Serializer B}
-           (bin: list bool) : option ((A * B) * list bool) :=
-  match deserialize bin with
-  | None => None
-  | Some (a, rest) =>
-  match deserialize rest with
-  | None => None
-  | Some (b, remainder) =>
-    Some ((a, b), remainder)
-  end
-  end.
-
-Lemma pair_serialize_reversible :
-  forall {A B: Type}
-    {aSerializer: Serializer A}
-    {bSerializer: Serializer B}
-    (p: A * B) (bin: list bool),
-    pair_deserialize (pair_serialize p ++ bin) = Some (p, bin).
-Proof.
-  intros.
-  unfold pair_serialize.
-  break_match.
-  unfold pair_deserialize.
-  rewrite app_assoc_reverse.
-  now repeat rewrite Serialize_reversible.
-Qed.
-
-Instance Pair_Serializer :
-  forall (A B: Type)
-    {aSerializer: Serializer A}
-    {bSerializer: Serializer B}, Serializer (A * B) :=
-  {
-    serialize := pair_serialize;
-    deserialize := pair_deserialize;
-    Serialize_reversible := pair_serialize_reversible
-  }.
-
-Definition triple_serialize
-           {A B C: Type}
-           {aSerializer: Serializer A}
-           {bSerializer: Serializer B}
-           {cSerializer: Serializer C}
-           (t: A*B*C) :=
-  let (p, c) := t in
-  let (a, b) := p in
-  (serialize a) ++ (serialize b) ++ (serialize c).
-
-Definition triple_deserialize
-           {A B C: Type}
-           {aSerializer: Serializer A}
-           {bSerializer: Serializer B}
-           {cSerializer: Serializer C}
-           (bin: list bool): option ((A*B*C) * list bool) :=
-  match deserialize bin with
-    | None => None
-    | Some (a, rest) =>
-  match deserialize rest with
+  Definition option_deserialize (bin: list bool) : option (option A * list bool) :=
+    match deserialize bin with
     | None => None
     | Some (b, rest) =>
-  match deserialize rest with
+    match b with
+    | false => Some (None, rest)
+    | true =>
+    match deserialize rest with
+    | None => None
+    | Some (t, rest) =>
+      Some (Some t, rest)
+    end
+    end
+    end.
+
+  Lemma option_serialize_reversible :
+    forall (o: option A) (bin: list bool),
+      option_deserialize (option_serialize o ++ bin) = Some (o, bin).
+  Proof.
+    unfold option_deserialize, option_serialize.
+    intros o bin.
+    destruct o; simpl; auto.
+    now rewrite Serialize_reversible.
+  Qed.
+
+  (* Global here means "redeclare this instance outside the section."
+     If you leave this off, then the instance must be manually re-declared. *)
+  Global Instance Option_Serializer : Serializer (option A) :=
+    {
+      serialize := option_serialize;
+      deserialize := option_deserialize;
+      Serialize_reversible := option_serialize_reversible
+    }.
+
+  Variable B : Type.
+  Variable sB : Serializer B.
+
+  Definition pair_serialize (p: A*B) :=
+    let (a, b) := p in
+    (serialize a) ++ (serialize b).
+
+  Definition pair_deserialize (bin: list bool) : option ((A * B) * list bool) :=
+    match deserialize bin with
+    | None => None
+    | Some (a, rest) =>
+    match deserialize rest with
+    | None => None
+    | Some (b, remainder) =>
+      Some ((a, b), remainder)
+    end
+    end.
+
+  Lemma pair_serialize_reversible :
+    forall (p: A * B) (bin: list bool),
+      pair_deserialize (pair_serialize p ++ bin) = Some (p, bin).
+  Proof.
+    intros.
+    unfold pair_serialize.
+    break_match.
+    unfold pair_deserialize.
+    rewrite app_assoc_reverse.
+    now repeat rewrite Serialize_reversible.
+  Qed.
+
+  Global Instance Pair_Serializer : Serializer (A * B) :=
+    {
+      serialize := pair_serialize;
+      deserialize := pair_deserialize;
+      Serialize_reversible := pair_serialize_reversible
+    }.
+
+  Variable C : Type.
+  Variable sC : Serializer C.
+
+  Definition triple_serialize (t: A*B*C) :=
+    let (p, c) := t in
+    let (a, b) := p in
+    (serialize a) ++ (serialize b) ++ (serialize c).
+
+  Definition triple_deserialize (bin: list bool): option ((A*B*C) * list bool) :=
+    match deserialize bin with
+    | None => None
+    | Some (a, rest) =>
+    match deserialize rest with
+    | None => None
+    | Some (b, rest) =>
+    match deserialize rest with
     | None => None
     | Some (c, remainder) =>
       Some ((a, b, c), remainder)
-  end
-  end
-  end.
+    end
+    end
+    end.
 
-Lemma triple_serialize_reversible :
-  forall {A B C: Type}
-    {aSerializer: Serializer A}
-    {bSerializer: Serializer B}
-    {cSerializer: Serializer C}
-    (t: A * B * C) (bin: list bool),
-    triple_deserialize (triple_serialize t ++ bin) = Some (t, bin).
-Proof.
-  intros.
-  unfold triple_serialize.
-  repeat break_match.
-  unfold triple_deserialize.
-  repeat rewrite app_assoc_reverse.
-  now repeat rewrite Serialize_reversible.
-Qed.
+  Lemma triple_serialize_reversible :
+    forall (t: A * B * C) (bin: list bool),
+      triple_deserialize (triple_serialize t ++ bin) = Some (t, bin).
+  Proof.
+    intros.
+    unfold triple_serialize.
+    repeat break_match.
+    unfold triple_deserialize.
+    repeat rewrite app_assoc_reverse.
+    now repeat rewrite Serialize_reversible.
+  Qed.
 
-Instance Triple_Serializer :
-  forall (A B C: Type)
-    {aSerializer: Serializer A}
-    {bSerializer: Serializer B}
-    {cSerializer: Serializer C}, Serializer (A * B * C) :=
-  {
-    serialize := triple_serialize;
-    deserialize := triple_deserialize;
-    Serialize_reversible := triple_serialize_reversible
-  }.
+  Global Instance Triple_Serializer : Serializer (A * B * C) :=
+    {
+      serialize := triple_serialize;
+      deserialize := triple_deserialize;
+      Serialize_reversible := triple_serialize_reversible
+    }.
 
-Fixpoint list_serialize_rec
-         {T: Type}
-         {tSerializer: Serializer T}
-         (ts: list T) := 
-  match ts with
+  Fixpoint list_serialize_rec (ts: list A) :=
+    match ts with
     | nil => nil
     | hd :: ts => (serialize hd) ++ (list_serialize_rec ts)
-  end.
+    end.
 
-Definition list_serialize
-           {T: Type}
-           {tSerializer: Serializer T}
-           (ts: list T) :=
-  serialize (length ts) ++ (list_serialize_rec ts).
+  Definition list_serialize (ts: list A) :=
+    serialize (length ts) ++ (list_serialize_rec ts).
 
-Fixpoint list_deserialize_rec
-         {T: Type}
-         {tSerializer: Serializer T}
-         (count: nat) (bin: list bool) :=
-  match count with
-    | 0 => Some (nil, bin)
-    | S n =>
-  match deserialize bin with
-    | None => None
-    | Some (t, rest) =>
-  match list_deserialize_rec n rest with
-    | None => None
-    | Some (elements, rest) => Some ((t :: elements), rest)
-  end
-  end
-  end.
+  Fixpoint list_deserialize_rec (count: nat) (bin: list bool) : option (list A * list bool) :=
+    match count with
+      | 0 => Some (nil, bin)
+      | S n =>
+    match deserialize bin with
+      | None => None
+      | Some (t, rest) =>
+    match list_deserialize_rec n rest with
+      | None => None
+      | Some (elements, rest) => Some ((t :: elements), rest)
+    end
+    end
+    end.
 
-Definition list_deserialize
-           {T: Type}
-           {tSerializer: Serializer T}
-           (bin: list bool) : option (list T * list bool) :=
-  match deserialize bin with
+  Definition list_deserialize (bin: list bool) : option (list A * list bool) :=
+    match deserialize bin with
     | None => None
     | Some (count, rest) =>
       list_deserialize_rec count rest
-  end.
+    end.
 
-Lemma list_serialize_reversible :
-  forall {T: Type}
-    {tSerializer: Serializer T}
-    (ts: list T) (bin: list bool),
-    list_deserialize (list_serialize ts ++ bin) = Some (ts, bin).
-Proof.
-  unfold list_deserialize, list_serialize.
-  intros T tSerializer ts bin.
-  rewrite app_assoc_reverse.
-  rewrite Serialize_reversible.
-  induction ts; auto.
-  simpl.
-  rewrite app_assoc_reverse.
-  rewrite Serialize_reversible.
-  now rewrite IHts.
-Qed.
+  Lemma list_serialize_reversible :
+    forall (ts: list A) (bin: list bool),
+      list_deserialize (list_serialize ts ++ bin) = Some (ts, bin).
+  Proof.
+    unfold list_deserialize, list_serialize.
+    intros ts bin.
+    rewrite app_assoc_reverse.
+    rewrite Serialize_reversible.
+    induction ts; auto.
+    simpl.
+    rewrite app_assoc_reverse.
+    rewrite Serialize_reversible.
+    now rewrite IHts.
+  Qed.
 
-Instance List_Serializer :
-  forall (T: Type)
-    {tSerializer: Serializer T},
-    Serializer (list T) :=
-  {
-    serialize := list_serialize;
-    deserialize := list_deserialize;
-    Serialize_reversible := list_serialize_reversible
-  }.
+  Global Instance List_Serializer : Serializer (list A) :=
+    {
+      serialize := list_serialize;
+      deserialize := list_deserialize;
+      Serialize_reversible := list_serialize_reversible
+    }.
+End combinators.

--- a/lib/Combinators.v
+++ b/lib/Combinators.v
@@ -1,6 +1,7 @@
 Require Import StructTactics.
 Require Import List.
 Require Import Types.
+Require Import ZArith.
 
 Section combinators.
   Variable A : Type.
@@ -204,4 +205,36 @@ Section combinators.
     }.
 End combinators.
 Implicit Arguments To_From_Serializer.
+
+Definition Z_to_nat (z : Z) : nat := 2 * (Z.abs_nat z) + Nat.b2n (0 <=? z)%Z.
+
+Definition nat_to_Z (n : nat) : Z :=
+  let abs := Z.of_nat (Nat.div2 n)
+  in
+  if Nat.odd n
+  then abs
+  else Z.opp abs.
+
+Lemma odd_b2n :
+  forall b, Nat.odd (Nat.b2n b) = b.
+Proof.
+  destruct b; auto.
+Qed.
+
+Lemma Z_to_nat_inverse :
+  forall z, nat_to_Z (Z_to_nat z) = z.
+Proof.
+  unfold nat_to_Z, Z_to_nat.
+  intros z.
+  rewrite Nat.div2_div, plus_comm, Nat.add_b2n_double_div2, Zabs2Nat.id_abs.
+  rewrite Nat.odd_add_mul_2, odd_b2n.
+  break_if.
+  - apply Z.leb_le in Heqb.
+    now rewrite Z.abs_eq by omega.
+  - apply Z.leb_gt in Heqb.
+    destruct (Z.abs_spec z); intuition.
+Qed.
+
+Instance Z_Serializer : Serializer Z :=
+  To_From_Serializer Nat_Serializer _ _ Z_to_nat_inverse.
 

--- a/lib/Types.v
+++ b/lib/Types.v
@@ -33,32 +33,11 @@ Instance Bool_Serializer: Serializer bool :=
     Serialize_reversible := bool_serialize_reversible
   }.
 
-Definition nat_serialize (n : nat) : list bool :=
-  let bin := nat_to_binary n
-  in nat_to_unary (length bin) ++ bin.
-
-Definition nat_deserialize (bin : list bool) : option (nat * list bool) :=
-  match unary_to_nat bin with None => None
-  | Some (n, bin) =>
-  match take n bin with None => None
-  | Some (bin_n, bin) =>
-    Some (binary_to_nat bin_n, bin)
-  end
-  end.
-
-Lemma nat_serialize_reversible : forall n bin,
-    nat_deserialize (nat_serialize n ++ bin) = Some (n, bin).
-Proof.
-  unfold nat_deserialize, nat_serialize.
-  intros n bin.
-  now rewrite app_assoc_reverse, nat_to_unary_to_nat, take_app, binary_to_nat_to_binary.
-Qed.
-
 Instance Nat_Serializer : Serializer nat :=
   {
-    serialize := nat_serialize;
-    deserialize := nat_deserialize;
-    Serialize_reversible := nat_serialize_reversible
+    serialize := uleb128_encode;
+    deserialize := uleb128_decode;
+    Serialize_reversible := uleb128_decode_encode
   }.
 
 Definition ascii_serialize (a : ascii) : list bool :=


### PR DESCRIPTION
If a type `B` is convertible to and from a serializable type `A`, then one can serialize elements of `B` by converting to `A` and then serializing. Deserialization first deserializes to an `A` and then "un-converts" it to a `B`.

I used this to produce a serializer for `Z`.
